### PR TITLE
SPARQLs for ddgatve website

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,4 @@ http://127.0.0.1:5000/eliozo/problem?problemid=LT.LJKMO.2018.7_8.6
 
 http://127.0.0.1:5000/eliozo/skill_tasks?skillIdentifier=comb.full
 (pirmajam uzdevumam pēc formulas lapas platumā ir sajaukta atkāpe). 
+Drusku zemāk salūzt fonti - kļūst ļoti mazi burti.

--- a/eliozoapp/eliozo/__init__.py
+++ b/eliozoapp/eliozo/__init__.py
@@ -18,10 +18,10 @@ def getSPARQLtopics():
     'PREFIX skos: <http://www.w3.org/2004/02/skos/core#>\n'+
     'PREFIX eliozo: <http://www.dudajevagatve.lv/eliozo#>\n'+
     '''SELECT DISTINCT ?skillIdentifier ?skillNumber ?skillDescription ?problemid WHERE { 
-    ?skill eliozo:skillIdentifier ?skillIdentifier .
+    ?skill eliozo:skillID ?skillIdentifier .
     ?skill eliozo:skillNumber ?skillNumber .
     ?skill eliozo:skillDescription ?skillDescription .
-    OPTIONAL {?prob eliozo:skill ?skill . ?prob eliozo:problemid ?problemid . }.
+    OPTIONAL {?prob eliozo:hasSkill ?skill . ?prob eliozo:problemID ?problemid . }.
     } ORDER BY ?skillNumber'''
     }
 
@@ -41,20 +41,20 @@ def getSPARQLProblem(arg):
     'PREFIX skos: <http://www.w3.org/2004/02/skos/core#>\n'+
     'PREFIX eliozo: <http://www.dudajevagatve.lv/eliozo#>\n'+
 'SELECT * WHERE { \n'+ 
-  '?problem eliozo:problemid \'{problemid}\' .\n' .format(problemid=arg)+
+  '?problem eliozo:problemID \'{problemid}\' .\n' .format(problemid=arg)+
   '''OPTIONAL {
-    ?problem eliozo:text ?text ;
-             eliozo:year ?year ;
+    ?problem eliozo:problemText ?text ;
+             eliozo:problemYear ?year ;
              eliozo:olympiad ?olympiad ;
-             eliozo:grade ?grade ;
+             eliozo:problemGrade ?grade ;
              eliozo:country ?country .
              } .
       OPTIONAL {
-        ?problem eliozo:skill ?skill .
-        ?skill eliozo:skillIdentifier ?skillIdentifier .
+        ?problem eliozo:hasSkill ?skill .
+        ?skill eliozo:skillID ?skillIdentifier .
     } .
       OPTIONAL {
-        ?problem eliozo:video ?video .
+        ?problem eliozo:hasVideo ?video .
     } .
       OPTIONAL {
         ?problem eliozo:image ?image .
@@ -82,10 +82,10 @@ def getSkillProblemsSPARQL(skillID):
 WHERE {
     ?parent skos:prefLabel \''''+skillID+'''\'  .
     ?parent skos:narrower* ?subskill .
-    ?problem eliozo:skill ?subskill ;
-             eliozo:problemid ?problemid ;
-             eliozo:text ?text ;
-             eliozo:grade ?grade .
+    ?problem eliozo:hasSkill ?subskill ;
+             eliozo:problemID ?problemid ;
+             eliozo:problemText ?text ;
+             eliozo:problemGrade ?grade .
 } ORDER BY ?grade
  '''
 
@@ -150,7 +150,7 @@ def getSPARQLOlympiadYears(country, olympiad):
     'PREFIX eliozo:<http://www.dudajevagatve.lv/eliozo#>\n'+
     'SELECT DISTINCT ?year ?grade WHERE { ?problem eliozo:country \''+country+
     '\' ; eliozo:olympiad \''+olympiad+
-    '\' ; eliozo:year ?year ; eliozo:grade ?grade . } ORDER BY ?year ?grade'
+    '\' ; eliozo:problemYear ?year ; eliozo:problemGrade ?grade . } ORDER BY ?year ?grade'
     }
 
     head = {'Content-Type' : 'application/x-www-form-urlencoded'}
@@ -169,12 +169,12 @@ def getSPARQLOlympiadGrades(year, country, grade, olympiad):
     'PREFIX skos: <http://www.w3.org/2004/02/skos/core#>\n'+
     'PREFIX eliozo:<http://www.dudajevagatve.lv/eliozo#>\n'+
     '''SELECT ?text ?problemid ?problem_number WHERE {
-  ?problem eliozo:year \''''+year+'''\' .
+  ?problem eliozo:problemYear \''''+year+'''\' .
   ?problem eliozo:country \''''+country+'''\' .
-  ?problem eliozo:text ?text .
-  ?problem eliozo:problemid ?problemid .
+  ?problem eliozo:problemText ?text .
+  ?problem eliozo:problemID ?problemid .
   ?problem eliozo:problem_number ?problem_number .
-  ?problem eliozo:grade '''+grade+''' .
+  ?problem eliozo:problemGrade '''+grade+''' .
   ?problem eliozo:olympiad \''''+olympiad+'''\' .
 } ORDER BY ?problem_number'''
     }
@@ -197,15 +197,15 @@ def getSPARQLVideoBookmarks(problemid):
     'PREFIX skos: <http://www.w3.org/2004/02/skos/core#>\n'+
     'PREFIX eliozo:<http://www.dudajevagatve.lv/eliozo#>\n'+
     '''SELECT ?videoTitle ?youtubeID ?tstamp ?bmtext WHERE {
-  ?problem eliozo:problemid \''''+problemid+'''\' .
+  ?problem eliozo:problemID \''''+problemid+'''\' .
   OPTIONAL {
-    ?problem eliozo:video ?video .
+    ?problem eliozo:hasVideo ?video .
     ?video eliozo:videoTitle ?videoTitle ;
-           eliozo:youtubeID ?youtubeID ;
+           eliozo:videoYoutube ?youtubeID ;
            eliozo:videoBookmarks ?videoBookmarks .
     ?videoBookmarks ?prop ?bookmark .
-    ?bookmark eliozo:tstamp ?tstamp ;
-              eliozo:bmtext ?bmtext .
+    ?bookmark eliozo:videoBookmarkTstamp ?tstamp ;
+              eliozo:videoBookmarkText ?bmtext .
   }.
 } ORDER BY ?tstamp'''
     }
@@ -226,8 +226,9 @@ def getAllSPARQLVideos():
     'PREFIX skos: <http://www.w3.org/2004/02/skos/core#>\n'+
     'PREFIX eliozo:<http://www.dudajevagatve.lv/eliozo#>\n'+
     '''SELECT ?problemid WHERE {
-  ?problem eliozo:problemid ?problemid .
-  	?problem eliozo:video ?video .         
+  ?problem eliozo:problemID ?problemid ;
+           eliozo:problemGrade ?grade ;
+  	       eliozo:hasVideo ?video .         
   } ORDER BY ?grade'''
     }
 

--- a/migration-script/csv_to_skos.py
+++ b/migration-script/csv_to_skos.py
@@ -37,7 +37,7 @@ def readCSVfile(g): # Funkcija, kas lasa CSV failu
 def addToRdfGraph(g, numeric_id, skillID, skillDescription, prefLabel, parentSkill_id):
     global eliozo_ns
     skill_node = rdflib.URIRef(eliozo_ns+skillID) # RDF subjekts
-    # skill_numeric_id_property = rdflib.URIRef(eliozo_ns+'skillNumber') # 1 0 0 0
+    skill_numeric_id_property = rdflib.URIRef(eliozo_ns+'skillNumber') # 1 0 0 0
     skill_id_property = rdflib.URIRef(eliozo_ns+'skillID') # alg.expr
     skill_description_property = rdflib.URIRef(eliozo_ns+'skillDescription') # Fiksēts URL, kas apraksta RDF predikātu
     skill_name_property = rdflib.URIRef(eliozo_ns+'skillName')
@@ -50,7 +50,7 @@ def addToRdfGraph(g, numeric_id, skillID, skillDescription, prefLabel, parentSki
     g.add((skill_node, skill_description_property, skill_description_object))
     g.add((skill_node, skill_name_property, rdflib.term.Literal('TBD')))
     g.add((skill_node, skill_rdf_type_property, rdflib.URIRef(eliozo_ns+"Skill")))
-    # g.add((skill_node, skill_numeric_id_property, rdflib.term.Literal(numeric_id)))
+    g.add((skill_node, skill_numeric_id_property, rdflib.term.Literal(numeric_id)))
     g.add((skill_node, skill_prefLabel_property, rdflib.term.Literal(prefLabel)))
     if parentSkill_id != '':
         parent_skill_node = rdflib.URIRef(eliozo_ns+parentSkill_id)

--- a/migration-script/resources/skos.ttl
+++ b/migration-script/resources/skos.ttl
@@ -5,6 +5,7 @@ eliozo:alg.equ.guess a eliozo:Skill ;
     eliozo:skillDescription "Ievietot dažas mainīgo vērtības sakņu uzminēšanai" ;
     eliozo:skillID "alg.equ.guess" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.3.1.0.0" ;
     skos:broader eliozo:alg.equ ;
     skos:prefLabel "alg.equ.guess" .
 
@@ -12,6 +13,7 @@ eliozo:alg.equ.parametrize a eliozo:Skill ;
     eliozo:skillDescription "Parametrizēt vairāku mainīgo vienādojumu, pieņemot kādu no mainīgajiem par parametru" ;
     eliozo:skillID "alg.equ.parametrize" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.3.3.0.0" ;
     skos:broader eliozo:alg.equ ;
     skos:prefLabel "alg.equ.parametrize" .
 
@@ -19,6 +21,7 @@ eliozo:alg.equ.quadratic.discriminant a eliozo:Skill ;
     eliozo:skillDescription "Noteikt kvadrātvienādojuma sakņu skaitu pēc diskriminanta" ;
     eliozo:skillID "alg.equ.quadratic.discriminant" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.3.2.1.0" ;
     skos:broader eliozo:alg.equ.quadratic ;
     skos:prefLabel "alg.equ.quadratic.discriminant" .
 
@@ -26,6 +29,7 @@ eliozo:alg.equ.quadratic.roots a eliozo:Skill ;
     eliozo:skillDescription "Noteikt kvadrātvienādojuma reālās saknes, ja tās ir" ;
     eliozo:skillID "alg.equ.quadratic.roots" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.3.2.2.0" ;
     skos:broader eliozo:alg.equ.quadratic ;
     skos:prefLabel "alg.equ.quadratic.roots" .
 
@@ -33,6 +37,7 @@ eliozo:alg.expr.prop a eliozo:Skill ;
     eliozo:skillDescription "Izteikt kvalitatīvas skaitļu īpašības (dalāmi ar kko, pēc kārtas sekojoši, nepāru, pilni kvadrāti u.c.) ar mainīgo izteiksmēm" ;
     eliozo:skillID "alg.expr.prop" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.1.1.0.0" ;
     skos:broader eliozo:alg.expr ;
     skos:prefLabel "alg.expr.prop" .
 
@@ -40,6 +45,7 @@ eliozo:alg.expr.selectvar a eliozo:Skill ;
     eliozo:skillDescription "Izvēlēties vien nedaudzus nezināmos lielumus, ar ko izteikt citus" ;
     eliozo:skillID "alg.expr.selectvar" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.1.2.0.0" ;
     skos:broader eliozo:alg.expr ;
     skos:prefLabel "alg.expr.selectvar" .
 
@@ -47,6 +53,7 @@ eliozo:alg.ineq.equations a eliozo:Skill ;
     eliozo:skillDescription "Veselu skaitļu vienādojumos sašaurināt potenciālo atrisinājumu kopu, ja citi neapmierina novērtējumu. " ;
     eliozo:skillID "alg.ineq.equations" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.5.1.0.0" ;
     skos:broader eliozo:alg.ineq ;
     skos:prefLabel "alg.ineq.equations" .
 
@@ -54,6 +61,7 @@ eliozo:alg.ineq.monotonicity a eliozo:Skill ;
     eliozo:skillDescription "Pamatot vienādojuma sakņu neesamību veselos skaitļos, izmantojot monotonitāti" ;
     eliozo:skillID "alg.ineq.monotonicity" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.5.3.0.0" ;
     skos:broader eliozo:alg.ineq ;
     skos:prefLabel "alg.ineq.monotonicity" .
 
@@ -61,6 +69,7 @@ eliozo:alg.ineq.quadratic a eliozo:Skill ;
     eliozo:skillDescription "Risināt kvadrātnevienādības" ;
     eliozo:skillID "alg.ineq.quadratic" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.5.5.0.0" ;
     skos:broader eliozo:alg.ineq ;
     skos:prefLabel "alg.ineq.quadratic" .
 
@@ -68,6 +77,7 @@ eliozo:alg.ineq.square a eliozo:Skill ;
     eliozo:skillDescription "Izmantot to, ka kvadrāti ir nenegatīvi" ;
     eliozo:skillID "alg.ineq.square" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.5.4.0.0" ;
     skos:broader eliozo:alg.ineq ;
     skos:prefLabel "alg.ineq.square" .
 
@@ -75,6 +85,7 @@ eliozo:alg.ineq.transitive a eliozo:Skill ;
     eliozo:skillDescription "Pamatot nevienādību $a$ &lt; $c$, izmantojot $a$ &lt; $b$ un $b$ &lt; $c$" ;
     eliozo:skillID "alg.ineq.transitive" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.5.2.0.0" ;
     skos:broader eliozo:alg.ineq ;
     skos:prefLabel "alg.ineq.transitive" .
 
@@ -82,6 +93,7 @@ eliozo:alg.linear.comb a eliozo:Skill ;
     eliozo:skillDescription "Veidot citas lineāras kombinācijas" ;
     eliozo:skillID "alg.linear.comb" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.6.2.0.0" ;
     skos:broader eliozo:alg.linear ;
     skos:prefLabel "alg.linear.comb" .
 
@@ -89,6 +101,7 @@ eliozo:alg.linear.equations a eliozo:Skill ;
     eliozo:skillDescription "Veikt pārveidojumus ar lineāriem vienādojumiem" ;
     eliozo:skillID "alg.linear.equations" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.6.1.0.0" ;
     skos:broader eliozo:alg.linear ;
     skos:prefLabel "alg.linear.equations" .
 
@@ -96,6 +109,7 @@ eliozo:alg.poly.division a eliozo:Skill ;
     eliozo:skillDescription "Dalīt divus viena mainīgā polinomus, iegūstot dalījumu un atlikumu" ;
     eliozo:skillID "alg.poly.division" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.7.1.0.0" ;
     skos:broader eliozo:alg.poly ;
     skos:prefLabel "alg.poly.division" .
 
@@ -103,6 +117,7 @@ eliozo:alg.poly.homo a eliozo:Skill ;
     eliozo:skillDescription "Izmantot izteiksmju homogenitāti: saglabāt identitāti, to ar kaut ko piereizinot." ;
     eliozo:skillID "alg.poly.homo" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.7.2.0.0" ;
     skos:broader eliozo:alg.poly ;
     skos:prefLabel "alg.poly.homo" .
 
@@ -110,6 +125,7 @@ eliozo:alg.poly.prop.valdiff a eliozo:Skill ;
     eliozo:skillDescription "Secināt, ka veselu skaitļu polinoma vērtību starpība $P(a)-P(b)$ dalās ar $a-b$" ;
     eliozo:skillID "alg.poly.prop.valdiff" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.7.3.1.0" ;
     skos:broader eliozo:alg.poly.prop ;
     skos:prefLabel "alg.poly.prop.valdiff" .
 
@@ -117,6 +133,7 @@ eliozo:alg.series.mean a eliozo:Skill ;
     eliozo:skillDescription "Veikt darbības ar aritmētisko vidējo" ;
     eliozo:skillID "alg.series.mean" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.4.2.0.0" ;
     skos:broader eliozo:alg.series ;
     skos:prefLabel "alg.series.mean" .
 
@@ -124,6 +141,7 @@ eliozo:alg.series.prod a eliozo:Skill ;
     eliozo:skillDescription "Pārkārtot locekļus reizinājumos (arī ar daudzpunktiem), saīsināt daļu reizinājumus" ;
     eliozo:skillID "alg.series.prod" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.4.3.0.0" ;
     skos:broader eliozo:alg.series ;
     skos:prefLabel "alg.series.prod" .
 
@@ -131,6 +149,7 @@ eliozo:alg.series.sum a eliozo:Skill ;
     eliozo:skillDescription "Pārkārtot locekļus garās summās (arī ar daudzpunktiem)" ;
     eliozo:skillID "alg.series.sum" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.4.1.0.0" ;
     skos:broader eliozo:alg.series ;
     skos:prefLabel "alg.series.sum" .
 
@@ -138,6 +157,7 @@ eliozo:alg.sets.irrat a eliozo:Skill ;
     eliozo:skillDescription "Secināt par skaitļu racionalitāti vai iracionalitāti" ;
     eliozo:skillID "alg.sets.irrat" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.8.1.0.0" ;
     skos:broader eliozo:alg.sets ;
     skos:prefLabel "alg.sets.irrat" .
 
@@ -145,6 +165,7 @@ eliozo:alg.sets.sqrt.pythagoras a eliozo:Skill ;
     eliozo:skillDescription "Secināt par Pitagora trijnieku, $a^2+b^2=c^2$, īpašībām" ;
     eliozo:skillID "alg.sets.sqrt.pythagoras" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.8.2.1.0" ;
     skos:broader eliozo:alg.sets.sqrt ;
     skos:prefLabel "alg.sets.sqrt.pythagoras" .
 
@@ -152,6 +173,7 @@ eliozo:alg.tra.binom.complsquare a eliozo:Skill ;
     eliozo:skillDescription "Atdalīt pilnos kvadrātus" ;
     eliozo:skillID "alg.tra.binom.complsquare" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.2.1.2.0" ;
     skos:broader eliozo:alg.tra.binom ;
     skos:prefLabel "alg.tra.binom.complsquare" .
 
@@ -159,6 +181,7 @@ eliozo:alg.tra.binom.newton a eliozo:Skill ;
     eliozo:skillDescription "Atvērt iekavas izteiksmēs $(a+b)^n$ un $(a-b)^n$ (Ņūtona binomi)" ;
     eliozo:skillID "alg.tra.binom.newton" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.2.1.3.0" ;
     skos:broader eliozo:alg.tra.binom ;
     skos:prefLabel "alg.tra.binom.newton" .
 
@@ -166,6 +189,7 @@ eliozo:alg.tra.binom.square a eliozo:Skill ;
     eliozo:skillDescription "Atvērt iekavas izteiksmēs $(a+b)^2$ un $(a-b)^2$ un dalīt reizinātājos" ;
     eliozo:skillID "alg.tra.binom.square" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.2.1.1.0" ;
     skos:broader eliozo:alg.tra.binom ;
     skos:prefLabel "alg.tra.binom.square" .
 
@@ -173,6 +197,7 @@ eliozo:alg.tra.factor.powdiff a eliozo:Skill ;
     eliozo:skillDescription "Dalīt reizinātājos $a^n-b^n$" ;
     eliozo:skillID "alg.tra.factor.powdiff" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.2.2.2.0" ;
     skos:broader eliozo:alg.tra.factor ;
     skos:prefLabel "alg.tra.factor.powdiff" .
 
@@ -180,6 +205,7 @@ eliozo:alg.tra.factor.sqdiff a eliozo:Skill ;
     eliozo:skillDescription "Dalīt reizinātājos $a^2-b^2$" ;
     eliozo:skillID "alg.tra.factor.sqdiff" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.2.2.1.0" ;
     skos:broader eliozo:alg.tra.factor ;
     skos:prefLabel "alg.tra.factor.sqdiff" .
 
@@ -187,6 +213,7 @@ eliozo:alg.tra.frac a eliozo:Skill ;
     eliozo:skillDescription "Lietot daļu identiskos pārveidojumus" ;
     eliozo:skillID "alg.tra.frac" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.2.4.0.0" ;
     skos:broader eliozo:alg.tra ;
     skos:prefLabel "alg.tra.frac" .
 
@@ -194,6 +221,7 @@ eliozo:alg.tra.pow.nest a eliozo:Skill ;
     eliozo:skillDescription "Atvērt iekavas izteiksmē $(a^m)^n$" ;
     eliozo:skillID "alg.tra.pow.nest" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.2.3.1.0" ;
     skos:broader eliozo:alg.tra.pow ;
     skos:prefLabel "alg.tra.pow.nest" .
 
@@ -201,6 +229,7 @@ eliozo:alg.tra.pow.prod a eliozo:Skill ;
     eliozo:skillDescription "Atvērt iekavas izteiksmē $(ab)^n$" ;
     eliozo:skillID "alg.tra.pow.prod" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.2.3.2.0" ;
     skos:broader eliozo:alg.tra.pow ;
     skos:prefLabel "alg.tra.pow.prod" .
 
@@ -208,6 +237,7 @@ eliozo:comb.constr.alpha a eliozo:Skill ;
     eliozo:skillDescription "Konstruēt, aizpildot alfabētiskā secībā" ;
     eliozo:skillID "comb.constr.alpha" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "6.4.1.0.0" ;
     skos:broader eliozo:comb.constr ;
     skos:prefLabel "comb.constr.alpha" .
 
@@ -215,6 +245,7 @@ eliozo:comb.constr.color a eliozo:Skill ;
     eliozo:skillDescription "Pielietot tabulai krāsojumu (izvietot skaitļus šaha galdiņa rakstā utml.)" ;
     eliozo:skillID "comb.constr.color" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "6.4.3.0.0" ;
     skos:broader eliozo:comb.constr ;
     skos:prefLabel "comb.constr.color" .
 
@@ -222,6 +253,7 @@ eliozo:comb.constr.iterative a eliozo:Skill ;
     eliozo:skillDescription "Konstruēt ar iteratīviem uzlabojumiem" ;
     eliozo:skillID "comb.constr.iterative" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "6.4.2.0.0" ;
     skos:broader eliozo:comb.constr ;
     skos:prefLabel "comb.constr.iterative" .
 
@@ -229,6 +261,7 @@ eliozo:comb.constr.partition a eliozo:Skill ;
     eliozo:skillDescription "Pielietot citu dalījumu disjunktās apakškopās" ;
     eliozo:skillID "comb.constr.partition" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "6.4.4.0.0" ;
     skos:broader eliozo:comb.constr ;
     skos:prefLabel "comb.constr.partition" .
 
@@ -236,6 +269,7 @@ eliozo:comb.count.complement a eliozo:Skill ;
     eliozo:skillDescription "Skaitīt elementus interesējošās kopas papildinājumam/starpībai" ;
     eliozo:skillID "comb.count.complement" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "6.2.2.0.0" ;
     skos:broader eliozo:comb.count ;
     skos:prefLabel "comb.count.complement" .
 
@@ -243,6 +277,7 @@ eliozo:comb.count.inclexcl a eliozo:Skill ;
     eliozo:skillDescription "Izmantot \"ieslēgšanas-izslēgšanas\" saskaitīšanu" ;
     eliozo:skillID "comb.count.inclexcl" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "6.2.3.0.0" ;
     skos:broader eliozo:comb.count ;
     skos:prefLabel "comb.count.inclexcl" .
 
@@ -250,6 +285,7 @@ eliozo:comb.count.mult.norep a eliozo:Skill ;
     eliozo:skillDescription "Izmantot reizināšanas likumu bez atkārtojumiem" ;
     eliozo:skillID "comb.count.mult.norep" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "6.2.1.2.0" ;
     skos:broader eliozo:comb.count.mult ;
     skos:prefLabel "comb.count.mult.norep" .
 
@@ -257,6 +293,7 @@ eliozo:comb.count.mult.rep a eliozo:Skill ;
     eliozo:skillDescription "Izmantot reizināšanas likumu,  ja iespējami atkārtojumi" ;
     eliozo:skillID "comb.count.mult.rep" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "6.2.1.1.0" ;
     skos:broader eliozo:comb.count.mult ;
     skos:prefLabel "comb.count.mult.rep" .
 
@@ -264,6 +301,7 @@ eliozo:comb.full.backtrack a eliozo:Skill ;
     eliozo:skillDescription "Meklēt ar apakšgadījumu koka apstaigāšanu" ;
     eliozo:skillID "comb.full.backtrack" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "6.1.1.0.0" ;
     skos:broader eliozo:comb.full ;
     skos:prefLabel "comb.full.backtrack" .
 
@@ -271,6 +309,7 @@ eliozo:comb.full.syntax a eliozo:Skill ;
     eliozo:skillDescription "Sistemātiski pārbaudīt visus sintakses kokus (piemēram, aritmētisku izteiksmju rēbusos)" ;
     eliozo:skillID "comb.full.syntax" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "6.1.2.0.0" ;
     skos:broader eliozo:comb.full ;
     skos:prefLabel "comb.full.syntax" .
 
@@ -278,6 +317,7 @@ eliozo:comb.graph.bfs a eliozo:Skill ;
     eliozo:skillDescription "Lietot \"breadth first search\" algoritmu kokveida grafa apstaigāšanai" ;
     eliozo:skillID "comb.graph.bfs" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "6.3.2.0.0" ;
     skos:broader eliozo:comb.graph ;
     skos:prefLabel "comb.graph.bfs" .
 
@@ -285,6 +325,7 @@ eliozo:comb.graph.bipartite a eliozo:Skill ;
     eliozo:skillDescription "Izmantot apgalvojumus par divdaļīgiem grafiem" ;
     eliozo:skillID "comb.graph.bipartite" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "6.3.1.0.0" ;
     skos:broader eliozo:comb.graph ;
     skos:prefLabel "comb.graph.bipartite" .
 
@@ -292,6 +333,7 @@ eliozo:comb.graph.cycle a eliozo:Skill ;
     eliozo:skillDescription "Atrast orientētā/neorientētā grafā ciklu ar īpašību (Eilera, Hamiltona, visgarāko, utml.)" ;
     eliozo:skillID "comb.graph.cycle" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "6.3.3.0.0" ;
     skos:broader eliozo:comb.graph ;
     skos:prefLabel "comb.graph.cycle" .
 
@@ -299,6 +341,7 @@ eliozo:comb.grid.shapes.cutting a eliozo:Skill ;
     eliozo:skillDescription "Risināt rūtiņu laukumu sagriešanas uzdevumus" ;
     eliozo:skillID "comb.grid.shapes.cutting" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "6.5.1.1.0" ;
     skos:broader eliozo:comb.grid.shapes ;
     skos:prefLabel "comb.grid.shapes.cutting" .
 
@@ -306,6 +349,7 @@ eliozo:div.common.gcd.bezout a eliozo:Skill ;
     eliozo:skillDescription "Izmantot Bezū identitāti" ;
     eliozo:skillID "div.common.gcd.bezout" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.3.2.3.0" ;
     skos:broader eliozo:div.common.gcd ;
     skos:prefLabel "div.common.gcd.bezout" .
 
@@ -313,6 +357,7 @@ eliozo:div.common.gcd.euclid a eliozo:Skill ;
     eliozo:skillDescription "Izmantot Eiklīda algoritmu" ;
     eliozo:skillID "div.common.gcd.euclid" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.3.2.1.0" ;
     skos:broader eliozo:div.common.gcd ;
     skos:prefLabel "div.common.gcd.euclid" .
 
@@ -320,6 +365,7 @@ eliozo:div.common.gcd.subsequent a eliozo:Skill ;
     eliozo:skillDescription "Izmantot, ka $\\mbox{LKD}(n,n+1)=1$" ;
     eliozo:skillID "div.common.gcd.subsequent" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.3.2.2.0" ;
     skos:broader eliozo:div.common.gcd ;
     skos:prefLabel "div.common.gcd.subsequent" .
 
@@ -327,6 +373,7 @@ eliozo:div.common.lcm.frac a eliozo:Skill ;
     eliozo:skillDescription "Izmantot MKD racionālu daļu saskaitīšanā" ;
     eliozo:skillID "div.common.lcm.frac" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.3.1.3.0" ;
     skos:broader eliozo:div.common.lcm ;
     skos:prefLabel "div.common.lcm.frac" .
 
@@ -334,6 +381,7 @@ eliozo:div.common.lcm.maxexp a eliozo:Skill ;
     eliozo:skillDescription "Iegūt LKD vai MKD no skaitļu sadalījumiem pirmreizinātājos (attiecīgi minimums vai maksimums no pirmskaitļu pakāpēm)" ;
     eliozo:skillID "div.common.lcm.maxexp" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.3.1.1.0" ;
     skos:broader eliozo:div.common.lcm ;
     skos:prefLabel "div.common.lcm.maxexp" .
 
@@ -341,6 +389,7 @@ eliozo:div.common.lcm.mult a eliozo:Skill ;
     eliozo:skillDescription "Atrast visus divu skaitļu kopīgos dalāmos formā $\\mbox{MKD}(a,b) \\cdot k$" ;
     eliozo:skillID "div.common.lcm.mult" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.3.1.2.0" ;
     skos:broader eliozo:div.common.lcm ;
     skos:prefLabel "div.common.lcm.mult" .
 
@@ -348,6 +397,7 @@ eliozo:div.fta.divisors.frac a eliozo:Skill ;
     eliozo:skillDescription "Pāriet no skaitļa dalītāju aplūkošanas uz daļskaitļu aplūkošanu" ;
     eliozo:skillID "div.fta.divisors.frac" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.2.2.2.0" ;
     skos:broader eliozo:div.fta.divisors ;
     skos:prefLabel "div.fta.divisors.frac" .
 
@@ -355,6 +405,7 @@ eliozo:div.fta.divisors.num a eliozo:Skill ;
     eliozo:skillDescription "Atrast skaitļa dalītāju skaitu un visus dalītājus pēc tā sadalījuma pirmreizinātājos" ;
     eliozo:skillID "div.fta.divisors.num" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.2.2.3.0" ;
     skos:broader eliozo:div.fta.divisors ;
     skos:prefLabel "div.fta.divisors.num" .
 
@@ -362,6 +413,7 @@ eliozo:div.fta.divisors.pair a eliozo:Skill ;
     eliozo:skillDescription "Izmantot skaitļa pozitīvo dalītāju sadalāmību pāros" ;
     eliozo:skillID "div.fta.divisors.pair" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.2.2.1.0" ;
     skos:broader eliozo:div.fta.divisors ;
     skos:prefLabel "div.fta.divisors.pair" .
 
@@ -369,6 +421,7 @@ eliozo:div.fta.divisors.struct a eliozo:Skill ;
     eliozo:skillDescription "Izkārtot skaitļa visus pozitīvos dalītājus \"taisnstūrainā\" struktūrā, sadalot pa pāriem, u.c." ;
     eliozo:skillID "div.fta.divisors.struct" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.2.2.5.0" ;
     skos:broader eliozo:div.fta.divisors ;
     skos:prefLabel "div.fta.divisors.struct" .
 
@@ -376,6 +429,7 @@ eliozo:div.fta.divisors.test a eliozo:Skill ;
     eliozo:skillDescription "Pamatot dalāmību ar saliktu skaitli d, pārbaudot d pirmreizinātāju augstākās pakāpes" ;
     eliozo:skillID "div.fta.divisors.test" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.2.2.4.0" ;
     skos:broader eliozo:div.fta.divisors ;
     skos:prefLabel "div.fta.divisors.test" .
 
@@ -383,6 +437,7 @@ eliozo:div.fta.factorial a eliozo:Skill ;
     eliozo:skillDescription "Izmantot faktoriāla dalījumu pirmreizinātājos" ;
     eliozo:skillID "div.fta.factorial" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.2.5.0.0" ;
     skos:broader eliozo:div.fta ;
     skos:prefLabel "div.fta.factorial" .
 
@@ -390,6 +445,7 @@ eliozo:div.fta.pow.expsystem a eliozo:Skill ;
     eliozo:skillDescription "Pārveidot veselu skaitļu vienādojumu par sistēmu, pielīdzinot pirmskaitļu kāpinātājus." ;
     eliozo:skillID "div.fta.pow.expsystem" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.2.4.0.0" ;
     skos:broader eliozo:div.fta.pow ;
     skos:prefLabel "div.fta.pow.expsystem" .
 
@@ -397,6 +453,7 @@ eliozo:div.fta.pow.other a eliozo:Skill ;
     eliozo:skillDescription "Noteikt citas pilnas pakāpes pēc tā, ka pirmreizinātāju kāpinātāji dalās ar lielākiem skaitļiem" ;
     eliozo:skillID "div.fta.pow.other" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.2.3.2.0" ;
     skos:broader eliozo:div.fta.pow ;
     skos:prefLabel "div.fta.pow.other" .
 
@@ -404,6 +461,7 @@ eliozo:div.fta.pow.square a eliozo:Skill ;
     eliozo:skillDescription "Noteikt pilnu kvadrātu pēc tā, ka pirmreizinātāju kāpinātāji ir pāru skaitļi" ;
     eliozo:skillID "div.fta.pow.square" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.2.3.1.0" ;
     skos:broader eliozo:div.fta.pow ;
     skos:prefLabel "div.fta.pow.square" .
 
@@ -411,6 +469,7 @@ eliozo:div.fta.proc a eliozo:Skill ;
     eliozo:skillDescription "Sadalīt skaitli ($<10000$) pirmreizinātājos, pārbaudot dalāmību līdz kvadrātsaknei." ;
     eliozo:skillID "div.fta.proc" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.2.1.0.0" ;
     skos:broader eliozo:div.fta ;
     skos:prefLabel "div.fta.proc" .
 
@@ -418,6 +477,7 @@ eliozo:div.prop.add a eliozo:Skill ;
     eliozo:skillDescription "Secināt, ka $d$ dala $a+b$ un $a-b$, ja $d \\mid a$ and $d \\mid b$" ;
     eliozo:skillID "div.prop.add" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.1.1.0.0" ;
     skos:broader eliozo:div.prop ;
     skos:prefLabel "div.prop.add" .
 
@@ -425,6 +485,7 @@ eliozo:div.prop.composite a eliozo:Skill ;
     eliozo:skillDescription "Pazīt saliktus skaitļus, pārbaudīt dalāmību līdz kvadrātsaknei" ;
     eliozo:skillID "div.prop.composite" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.1.4.0.0" ;
     skos:broader eliozo:div.prop ;
     skos:prefLabel "div.prop.composite" .
 
@@ -432,6 +493,7 @@ eliozo:div.prop.euclidlemma a eliozo:Skill ;
     eliozo:skillDescription "Lietot Eiklīda lemmu (ja p dala ab, tad a vai b dalās ar p)" ;
     eliozo:skillID "div.prop.euclidlemma" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.1.5.0.0" ;
     skos:broader eliozo:div.prop ;
     skos:prefLabel "div.prop.euclidlemma" .
 
@@ -439,6 +501,7 @@ eliozo:div.prop.primes.inf a eliozo:Skill ;
     eliozo:skillDescription "Izmantot faktu, ka pirmskaitļu ir bezgalīgi daudz" ;
     eliozo:skillID "div.prop.primes.inf" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.1.3.2.0" ;
     skos:broader eliozo:div.prop.primes ;
     skos:prefLabel "div.prop.primes.inf" .
 
@@ -446,6 +509,7 @@ eliozo:div.prop.primes.small a eliozo:Skill ;
     eliozo:skillDescription "Pazīt pirmskaitļus un saliktus skaitļus intervālā $[1;100]$" ;
     eliozo:skillID "div.prop.primes.small" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.1.3.1.0" ;
     skos:broader eliozo:div.prop.primes ;
     skos:prefLabel "div.prop.primes.small" .
 
@@ -453,6 +517,7 @@ eliozo:div.prop.prod a eliozo:Skill ;
     eliozo:skillDescription "Secināt, ka $xy$ dala $ab$, ja $x \\mid a$ and $y \\mid b$" ;
     eliozo:skillID "div.prop.prod" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.1.2.0.0" ;
     skos:broader eliozo:div.prop ;
     skos:prefLabel "div.prop.prod" .
 
@@ -460,6 +525,7 @@ eliozo:div.valu.change a eliozo:Skill ;
     eliozo:skillDescription "Izmantot p-valuācijas funkcijas vērtību izmaiņas" ;
     eliozo:skillID "div.valu.change" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.5.2.0.0" ;
     skos:broader eliozo:div.valu ;
     skos:prefLabel "div.valu.change" .
 
@@ -467,6 +533,7 @@ eliozo:div.valu.prop.legendre a eliozo:Skill ;
     eliozo:skillDescription "Lietot Ležandra formulu $v_p(n!)=[n/p]+[n/p^2]+\\ldots$" ;
     eliozo:skillID "div.valu.prop.legendre" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.5.1.1.1" ;
     skos:broader eliozo:div.valu.prop ;
     skos:prefLabel "div.valu.prop.legendre" .
 
@@ -474,6 +541,7 @@ eliozo:div.valu.prop.min a eliozo:Skill ;
     eliozo:skillDescription "Izmantot faktu: skaitļu summas valuācija ir saskaitāmo valuāciju minimums, ja tās atšķiras" ;
     eliozo:skillID "div.valu.prop.min" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.5.1.3.0" ;
     skos:broader eliozo:div.valu.prop ;
     skos:prefLabel "div.valu.prop.min" .
 
@@ -481,6 +549,7 @@ eliozo:div.valu.prop.other a eliozo:Skill ;
     eliozo:skillDescription "Izmantot valuāciju saskaitīšanu citiem gariem reizinājumiem" ;
     eliozo:skillID "div.valu.prop.other" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.5.1.1.2" ;
     skos:broader eliozo:div.valu.prop ;
     skos:prefLabel "div.valu.prop.other" .
 
@@ -488,6 +557,7 @@ eliozo:div.valu.prop.prod a eliozo:Skill ;
     eliozo:skillDescription "Izmantot faktu: skaitļu reizinājuma valuācija ir reizinātāju valuāciju summa" ;
     eliozo:skillID "div.valu.prop.prod" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.5.1.1.0" ;
     skos:broader eliozo:div.valu.prop ;
     skos:prefLabel "div.valu.prop.prod" .
 
@@ -495,6 +565,7 @@ eliozo:div.valu.prop.sum a eliozo:Skill ;
     eliozo:skillDescription "Izmantot faktu: skaitļu summas valuācija ir vismaz saskaitāmo valuāciju minimums" ;
     eliozo:skillID "div.valu.prop.sum" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.5.1.2.0" ;
     skos:broader eliozo:div.valu.prop ;
     skos:prefLabel "div.valu.prop.sum" .
 
@@ -502,6 +573,7 @@ eliozo:geom.circle.inscribed a eliozo:Skill ;
     eliozo:skillDescription "Izmantot riņķī ievilkta leņķa īpašības" ;
     eliozo:skillID "geom.circle.inscribed" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "8.2.1.0.0" ;
     skos:broader eliozo:geom.circle ;
     skos:prefLabel "geom.circle.inscribed" .
 
@@ -509,6 +581,7 @@ eliozo:geom.constr.small a eliozo:Skill ;
     eliozo:skillDescription "Izdarīt spriedumus, kuros ir \"ļoti mazi\" ģeometriski pārvietojumi" ;
     eliozo:skillID "geom.constr.small" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "8.1.2.0.0" ;
     skos:broader eliozo:geom.constr ;
     skos:prefLabel "geom.constr.small" .
 
@@ -516,6 +589,7 @@ eliozo:geom.constr.triangulate a eliozo:Skill ;
     eliozo:skillDescription "Veikt daudzstūru triangulāciju" ;
     eliozo:skillID "geom.constr.triangulate" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "8.1.1.0.0" ;
     skos:broader eliozo:geom.constr ;
     skos:prefLabel "geom.constr.triangulate" .
 
@@ -523,6 +597,7 @@ eliozo:geom.quadrangle.para a eliozo:Skill ;
     eliozo:skillDescription "Izmantot rombu un paralelogramu ģeometriskās īpašības" ;
     eliozo:skillID "geom.quadrangle.para" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "8.4.2.0.0" ;
     skos:broader eliozo:geom.quadrangle ;
     skos:prefLabel "geom.quadrangle.para" .
 
@@ -530,6 +605,7 @@ eliozo:geom.quadrangle.rect a eliozo:Skill ;
     eliozo:skillDescription "Izmantot kvadrātu un taisnstūru ģeometriskās īpašības" ;
     eliozo:skillID "geom.quadrangle.rect" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "8.4.1.0.0" ;
     skos:broader eliozo:geom.quadrangle ;
     skos:prefLabel "geom.quadrangle.rect" .
 
@@ -537,6 +613,7 @@ eliozo:geom.quadrangle.trapezoid.area a eliozo:Skill ;
     eliozo:skillDescription "Izmantot trapeču laukuma formulas" ;
     eliozo:skillID "geom.quadrangle.trapezoid.area" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "8.4.3.1.0" ;
     skos:broader eliozo:geom.quadrangle.trapezoid ;
     skos:prefLabel "geom.quadrangle.trapezoid.area" .
 
@@ -544,6 +621,7 @@ eliozo:geom.quandrangle a eliozo:Skill ;
     eliozo:skillDescription "Izmantot četrstūru ģeometriskās īpašības" ;
     eliozo:skillID "geom.quandrangle" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "8.4.0.0.0" ;
     skos:broader eliozo:geom ;
     skos:prefLabel "geom.quandrangle" .
 
@@ -551,6 +629,7 @@ eliozo:geom.triangle.area.ah2 a eliozo:Skill ;
     eliozo:skillDescription "Izmantot formulu $ah/2$" ;
     eliozo:skillID "geom.triangle.area.ah2" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "8.3.1.1.0" ;
     skos:broader eliozo:geom.triangle.area ;
     skos:prefLabel "geom.triangle.area.ah2" .
 
@@ -558,6 +637,7 @@ eliozo:geom.triangle.congruence a eliozo:Skill ;
     eliozo:skillDescription "Izmantot trijstūru vienādības pazīmes" ;
     eliozo:skillID "geom.triangle.congruence" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "8.3.2.0.0" ;
     skos:broader eliozo:geom.triangle ;
     skos:prefLabel "geom.triangle.congruence" .
 
@@ -565,6 +645,7 @@ eliozo:misc.extr.param a eliozo:Skill ;
     eliozo:skillDescription "Sākt risināt vienādojumu, ievietojot ekstrēmu parametra vai potenciālās saknes vērtību" ;
     eliozo:skillID "misc.extr.param" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "7.2.2.0.0" ;
     skos:broader eliozo:misc.extr ;
     skos:prefLabel "misc.extr.param" .
 
@@ -572,6 +653,7 @@ eliozo:misc.extr.pigeon.collection a eliozo:Skill ;
     eliozo:skillDescription "Izmantot Dirihlē principa vispārinājumu skaitļu komplektam" ;
     eliozo:skillID "misc.extr.pigeon.collection" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "7.2.1.3.0" ;
     skos:broader eliozo:misc.extr.pigeon ;
     skos:prefLabel "misc.extr.pigeon.collection" .
 
@@ -579,6 +661,7 @@ eliozo:misc.extr.pigeon.floor a eliozo:Skill ;
     eliozo:skillDescription "Izmantot Dirihlē principa vispārinājumu (n un m)" ;
     eliozo:skillID "misc.extr.pigeon.floor" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "7.2.1.2.0" ;
     skos:broader eliozo:misc.extr.pigeon ;
     skos:prefLabel "misc.extr.pigeon.floor" .
 
@@ -586,6 +669,7 @@ eliozo:misc.extr.pigeon.plain a eliozo:Skill ;
     eliozo:skillDescription "Izmantot Dirihlē principa tradicionālo formu (n un n+1)" ;
     eliozo:skillID "misc.extr.pigeon.plain" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "7.2.1.1.0" ;
     skos:broader eliozo:misc.extr.pigeon ;
     skos:prefLabel "misc.extr.pigeon.plain" .
 
@@ -593,6 +677,7 @@ eliozo:misc.ind.descent a eliozo:Skill ;
     eliozo:skillDescription "Lietot neierobežotā samazinājuma metodi (piemēram, pamatojot veselu skaitļu sakņu iracionalitāti, ja tās nav veseli skaitļi)" ;
     eliozo:skillID "misc.ind.descent" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "7.4.2.0.0" ;
     skos:broader eliozo:misc.ind ;
     skos:prefLabel "misc.ind.descent" .
 
@@ -600,6 +685,7 @@ eliozo:misc.ind.least a eliozo:Skill ;
     eliozo:skillDescription "Izmantot naturālo skaitļu sakārtojuma principu: katrā naturālu skaitļu kopā atradīsies vismazākais elements" ;
     eliozo:skillID "misc.ind.least" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "7.4.1.0.0" ;
     skos:broader eliozo:misc.ind ;
     skos:prefLabel "misc.ind.least" .
 
@@ -607,6 +693,7 @@ eliozo:misc.invar.congr a eliozo:Skill ;
     eliozo:skillDescription "Lietot atlikumu/kongruenci kā invariantu" ;
     eliozo:skillID "misc.invar.congr" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "7.3.2.0.0" ;
     skos:broader eliozo:misc.invar ;
     skos:prefLabel "misc.invar.congr" .
 
@@ -614,6 +701,7 @@ eliozo:misc.invar.expr a eliozo:Skill ;
     eliozo:skillDescription "Veidot un lietot citu izteiksmi kā invariantu" ;
     eliozo:skillID "misc.invar.expr" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "7.3.3.0.0" ;
     skos:broader eliozo:misc.invar ;
     skos:prefLabel "misc.invar.expr" .
 
@@ -621,6 +709,7 @@ eliozo:misc.invar.game a eliozo:Skill ;
     eliozo:skillDescription "Izveidot invariantu, kurš izpildās pēc katra uzvarētāja gājiena kombinatoriskā spēlē" ;
     eliozo:skillID "misc.invar.game" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "7.3.4.0.0" ;
     skos:broader eliozo:misc.invar ;
     skos:prefLabel "misc.invar.game" .
 
@@ -628,6 +717,7 @@ eliozo:misc.invar.parity a eliozo:Skill ;
     eliozo:skillDescription "Lietot paritāti kā invariantu" ;
     eliozo:skillID "misc.invar.parity" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "7.3.1.0.0" ;
     skos:broader eliozo:misc.invar ;
     skos:prefLabel "misc.invar.parity" .
 
@@ -635,6 +725,7 @@ eliozo:misc.symm.periodicity a eliozo:Skill ;
     eliozo:skillDescription "Izmantot virkņu periodiskumu, lai aplūkotu tikai vienu periodu. " ;
     eliozo:skillID "misc.symm.periodicity" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "7.5.2.0.0" ;
     skos:broader eliozo:misc.symm ;
     skos:prefLabel "misc.symm.periodicity" .
 
@@ -642,6 +733,7 @@ eliozo:misc.symm.rename a eliozo:Skill ;
     eliozo:skillDescription "Izmantot mainīgo pārsaukšanu simetriskā izteiksmē, lai izdarītu papildu pieņēmumus (teiksim, $a$ &lt; $b$)" ;
     eliozo:skillID "misc.symm.rename" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "7.5.1.0.0" ;
     skos:broader eliozo:misc.symm ;
     skos:prefLabel "misc.symm.rename" .
 
@@ -649,6 +741,7 @@ eliozo:misc.try a eliozo:Skill ;
     eliozo:skillDescription "Ievietot dažas nelielas vērtības, apkopot datus tabulās, izdarīt hipotēzes ar nepilno indukciju" ;
     eliozo:skillID "misc.try" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "7.1.0.0.0" ;
     skos:broader eliozo:misc ;
     skos:prefLabel "misc.try" .
 
@@ -656,6 +749,7 @@ eliozo:mod.congr.classes a eliozo:Skill ;
     eliozo:skillDescription "Izmantot apgalvojumu, ka atlikumi (mod d) pieņem d vērtības" ;
     eliozo:skillID "mod.congr.classes" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "3.2.1.0.0" ;
     skos:broader eliozo:mod.congr ;
     skos:prefLabel "mod.congr.classes" .
 
@@ -663,6 +757,7 @@ eliozo:mod.congr.poly a eliozo:Skill ;
     eliozo:skillDescription "Secināt $P(x)$ vērtību kongruenci, ja polinoma argumenti ir kongruenti" ;
     eliozo:skillID "mod.congr.poly" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "3.2.5.0.0" ;
     skos:broader eliozo:mod.congr ;
     skos:prefLabel "mod.congr.poly" .
 
@@ -670,6 +765,7 @@ eliozo:mod.congr.pow a eliozo:Skill ;
     eliozo:skillDescription "Secināt, ka $(a_1)^n$ un $(a_2)^n$ kongruenti (mod m), ja kongruenti $a_1$ ar $a_2$" ;
     eliozo:skillID "mod.congr.pow" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "3.2.4.0.0" ;
     skos:broader eliozo:mod.congr ;
     skos:prefLabel "mod.congr.pow" .
 
@@ -677,6 +773,7 @@ eliozo:mod.congr.prod a eliozo:Skill ;
     eliozo:skillDescription "Secināt, ka $a_1 \\cdot b_1$ un $a_2 \\cdot b_2$ kongruenti (mod m), ja kongruenti $a_1$ ar $a_2$ un $b_1$ ar $b_2$" ;
     eliozo:skillID "mod.congr.prod" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "3.2.3.0.0" ;
     skos:broader eliozo:mod.congr ;
     skos:prefLabel "mod.congr.prod" .
 
@@ -684,6 +781,7 @@ eliozo:mod.congr.sumdiff a eliozo:Skill ;
     eliozo:skillDescription "Secināt, ka summas/starpības $a_1+b_1$ un $a_2+b_2$ kongruenti (mod m), ja kongruenti $a_1$ ar $a_2$ un $b_1$ ar $b_$" ;
     eliozo:skillID "mod.congr.sumdiff" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "3.2.1.0.0" ;
     skos:broader eliozo:mod.congr ;
     skos:prefLabel "mod.congr.sumdiff" .
 
@@ -691,6 +789,7 @@ eliozo:mod.eq.chinese a eliozo:Skill ;
     eliozo:skillDescription "Izmantot ķīniešu atlikumu teorēmu" ;
     eliozo:skillID "mod.eq.chinese" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "3.6.3.0.0" ;
     skos:broader eliozo:mod.eq ;
     skos:prefLabel "mod.eq.chinese" .
 
@@ -698,6 +797,7 @@ eliozo:mod.eq.contradict a eliozo:Skill ;
     eliozo:skillDescription "Secināt, ka veselu skaitļu vienādojumam nav atrisinājumu kongruenču pretrunas dēļ" ;
     eliozo:skillID "mod.eq.contradict" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "3.6.2.0.0" ;
     skos:broader eliozo:mod.eq ;
     skos:prefLabel "mod.eq.contradict" .
 
@@ -705,6 +805,7 @@ eliozo:mod.eq.linear a eliozo:Skill ;
     eliozo:skillDescription "Risināt lineāras kongruences, piemēram, izmantojot inversos elementus." ;
     eliozo:skillID "mod.eq.linear" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "3.6.1.0.0" ;
     skos:broader eliozo:mod.eq ;
     skos:prefLabel "mod.eq.linear" .
 
@@ -712,6 +813,7 @@ eliozo:mod.exp.fermat a eliozo:Skill ;
     eliozo:skillDescription "Lietot Mazo Fermā teorēmu: $a^{p-1}$ kongruents ar 1 katram pirmskaitlim $p$, ja $LKD(a,p)=1$" ;
     eliozo:skillID "mod.exp.fermat" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "3.4.3.0.0" ;
     skos:broader eliozo:mod.exp ;
     skos:prefLabel "mod.exp.fermat" .
 
@@ -719,6 +821,7 @@ eliozo:mod.exp.inverse a eliozo:Skill ;
     eliozo:skillDescription "Lietot inversās kongruenču klases, katram (mod m) noteikt, kad tās eksistē." ;
     eliozo:skillID "mod.exp.inverse" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "3.4.2.0.0" ;
     skos:broader eliozo:mod.exp ;
     skos:prefLabel "mod.exp.inverse" .
 
@@ -726,6 +829,7 @@ eliozo:mod.exp.period a eliozo:Skill ;
     eliozo:skillDescription "Izmantot eksponentfunkciju atlikumu periodiskumu." ;
     eliozo:skillID "mod.exp.period" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "3.4.1.0.0" ;
     skos:broader eliozo:mod.exp ;
     skos:prefLabel "mod.exp.period" .
 
@@ -733,6 +837,7 @@ eliozo:mod.fix.clock a eliozo:Skill ;
     eliozo:skillDescription "Secināt par saskaitīšanu un atņemšanu pēc 12 stundu ciparnīcas vai nedēļas cikla." ;
     eliozo:skillID "mod.fix.clock" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "3.1.3.0.0" ;
     skos:broader eliozo:mod.fix ;
     skos:prefLabel "mod.fix.clock" .
 
@@ -740,6 +845,7 @@ eliozo:mod.fix.lastdigits a eliozo:Skill ;
     eliozo:skillDescription "Izmantot skaitļa pēdējos n ciparus kā atlikumu, dalot ar 10^n. Secināt par atlikumiem (dalot ar 10, 100, 2, 5 u.c.), zinot skaitļu decimālpieraksta pēdējo ciparu vai ciparus." ;
     eliozo:skillID "mod.fix.lastdigits" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "3.1.2.0.0" ;
     skos:broader eliozo:mod.fix ;
     skos:prefLabel "mod.fix.lastdigits" .
 
@@ -747,6 +853,7 @@ eliozo:mod.fix.parity a eliozo:Skill ;
     eliozo:skillDescription "Izmantot spriedumus par skaitļu paritāti; Pāriet uz galīga skaita gadījumu aplūkošanu atkarībā no pāra/nepāra" ;
     eliozo:skillID "mod.fix.parity" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "3.1.1.0.0" ;
     skos:broader eliozo:mod.fix ;
     skos:prefLabel "mod.fix.parity" .
 
@@ -754,6 +861,7 @@ eliozo:mod.period a eliozo:Skill ;
     eliozo:skillDescription "Izmantot citu atlikumu virkņu periodiskumu, ja katru nākamo atlikumu nosaka iepriekšējais (vai galīgs skaits iepriekšējo)" ;
     eliozo:skillID "mod.period" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "3.5.0.0.0" ;
     skos:broader eliozo:mod ;
     skos:prefLabel "mod.period" .
 
@@ -761,6 +869,7 @@ eliozo:nota.algor.arithm a eliozo:Skill ;
     eliozo:skillDescription "Veikt galīgas darbības stabiņā" ;
     eliozo:skillID "nota.algor.arithm" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.4.1.0.0" ;
     skos:broader eliozo:nota.algor ;
     skos:prefLabel "nota.algor.arithm" .
 
@@ -768,6 +877,7 @@ eliozo:nota.algor.fast a eliozo:Skill ;
     eliozo:skillDescription "Ātri veikt darbības, piemēram, kāpināt kvadrātā skaitļus, kuri beidzas ar 5" ;
     eliozo:skillID "nota.algor.fast" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.4.2.0.0" ;
     skos:broader eliozo:nota.algor ;
     skos:prefLabel "nota.algor.fast" .
 
@@ -775,6 +885,7 @@ eliozo:nota.algor.longdiv a eliozo:Skill ;
     eliozo:skillDescription "Veikt garo dalīšanu" ;
     eliozo:skillID "nota.algor.longdiv" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.4.3.0.0" ;
     skos:broader eliozo:nota.algor ;
     skos:prefLabel "nota.algor.longdiv" .
 
@@ -782,6 +893,7 @@ eliozo:nota.algor.nondec a eliozo:Skill ;
     eliozo:skillDescription "Izmantot nedecimālās sistēmas" ;
     eliozo:skillID "nota.algor.nondec" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.4.4.0.0" ;
     skos:broader eliozo:nota.algor ;
     skos:prefLabel "nota.algor.nondec" .
 
@@ -789,6 +901,7 @@ eliozo:nota.combine.padding a eliozo:Skill ;
     eliozo:skillDescription "Veidot jaunus piemērus, iespraužot skaitļa decimālpierakstā jaunus ciparus." ;
     eliozo:skillID "nota.combine.padding" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.3.3.0.0" ;
     skos:broader eliozo:nota.combine ;
     skos:prefLabel "nota.combine.padding" .
 
@@ -796,6 +909,7 @@ eliozo:nota.combine.poly.pieces a eliozo:Skill ;
     eliozo:skillDescription "Izteikt skaitli gan ar cipariem, gan garākiem gabaliem" ;
     eliozo:skillID "nota.combine.poly.pieces" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.3.1.1.0" ;
     skos:broader eliozo:nota.combine.poly ;
     skos:prefLabel "nota.combine.poly.pieces" .
 
@@ -803,6 +917,7 @@ eliozo:nota.combine.split a eliozo:Skill ;
     eliozo:skillDescription "Izteikt garu skaitli divos gabalos, piereizinot vienu no tiem ar $10^k$" ;
     eliozo:skillID "nota.combine.split" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.3.2.0.0" ;
     skos:broader eliozo:nota.combine ;
     skos:prefLabel "nota.combine.split" .
 
@@ -810,6 +925,7 @@ eliozo:nota.divrule.1001 a eliozo:Skill ;
     eliozo:skillDescription "Izmantot dalāmības pazīmes 1001 dalītājiem" ;
     eliozo:skillID "nota.divrule.1001" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.2.6.0.0" ;
     skos:broader eliozo:nota.divrule ;
     skos:prefLabel "nota.divrule.1001" .
 
@@ -817,6 +933,7 @@ eliozo:nota.divrule.101 a eliozo:Skill ;
     eliozo:skillDescription "Izmantot dalāmības pazīmi ar 101 (no beigām pārmaiņus pieskaita un atņem 2 ciparu grupiņas)" ;
     eliozo:skillID "nota.divrule.101" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.2.5.0.0" ;
     skos:broader eliozo:nota.divrule ;
     skos:prefLabel "nota.divrule.101" .
 
@@ -824,6 +941,7 @@ eliozo:nota.divrule.11 a eliozo:Skill ;
     eliozo:skillDescription "Izmantot dalāmības pazīmi ar 11" ;
     eliozo:skillID "nota.divrule.11" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.2.4.0.0" ;
     skos:broader eliozo:nota.divrule ;
     skos:prefLabel "nota.divrule.11" .
 
@@ -831,6 +949,7 @@ eliozo:nota.divrule.2_5_10.divides a eliozo:Skill ;
     eliozo:skillDescription "Secināt, ka skaitlis dalās ar 2 (vai 5, vai 10), ja tā pēdējais cipars dalās ar to un otrādi" ;
     eliozo:skillID "nota.divrule.2_5_10.divides" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.2.1.1.0" ;
     skos:broader eliozo:nota.divrule.2_5_10 ;
     skos:prefLabel "nota.divrule.2_5_10.divides" .
 
@@ -838,6 +957,7 @@ eliozo:nota.divrule.2_5_10.rem a eliozo:Skill ;
     eliozo:skillDescription "Secināt, ka atlikums, dalot ar 2 (vai 5, vai 10), sakrīt ar pēdējā cipara atlikumu" ;
     eliozo:skillID "nota.divrule.2_5_10.rem" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.2.1.2.0" ;
     skos:broader eliozo:nota.divrule.2_5_10 ;
     skos:prefLabel "nota.divrule.2_5_10.rem" .
 
@@ -845,6 +965,7 @@ eliozo:nota.divrule.2_5pow.divides a eliozo:Skill ;
     eliozo:skillDescription "Secināt, ka skaitlis dalās ar $2^a \\cdot 5^b$, ja max(a,b) pēdējie cipari dalās ar to" ;
     eliozo:skillID "nota.divrule.2_5pow.divides" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.2.2.1.0" ;
     skos:broader eliozo:nota.divrule.2_5pow ;
     skos:prefLabel "nota.divrule.2_5pow.divides" .
 
@@ -852,6 +973,7 @@ eliozo:nota.divrule.2_5pow.rem a eliozo:Skill ;
     eliozo:skillDescription "Secināt, ka atlikums, dalot ar $2^a \\cdot 5^b$, sakrīt ar pēdējo max(a,b) ciparu atlikumu" ;
     eliozo:skillID "nota.divrule.2_5pow.rem" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.2.2.2.0" ;
     skos:broader eliozo:nota.divrule.2_5pow ;
     skos:prefLabel "nota.divrule.2_5pow.rem" .
 
@@ -859,6 +981,7 @@ eliozo:nota.divrule.3_9.divides a eliozo:Skill ;
     eliozo:skillDescription "Secināt, ka skaitlis dalās ar 3 (vai 9), ja tā ciparu summa dalās ar 3 (vai 9) un otrādi" ;
     eliozo:skillID "nota.divrule.3_9.divides" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.2.3.1.0" ;
     skos:broader eliozo:nota.divrule.3_9 ;
     skos:prefLabel "nota.divrule.3_9.divides" .
 
@@ -866,6 +989,7 @@ eliozo:nota.divrule.3_9.rem a eliozo:Skill ;
     eliozo:skillDescription "Secināt, ka atlikums, dalot ar 3 (vai 9), sakrīt ar ciparu summas atlikumu" ;
     eliozo:skillID "nota.divrule.3_9.rem" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.2.3.2.0" ;
     skos:broader eliozo:nota.divrule.3_9 ;
     skos:prefLabel "nota.divrule.3_9.rem" .
 
@@ -873,6 +997,7 @@ eliozo:nota.divrule.composite a eliozo:Skill ;
     eliozo:skillDescription "Izmantot kombinētās dalāmības pazīmes skaitļa decimālpierakstā (ar 2 un 3 utml.)" ;
     eliozo:skillID "nota.divrule.composite" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.2.5.0.0" ;
     skos:broader eliozo:nota.divrule ;
     skos:prefLabel "nota.divrule.composite" .
 
@@ -880,6 +1005,7 @@ eliozo:nota.est.numdigits.prod a eliozo:Skill ;
     eliozo:skillDescription "Novērtēt ciparu skaitu divu skaitļu reizinājumā" ;
     eliozo:skillID "nota.est.numdigits.prod" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.1.1.2.0" ;
     skos:broader eliozo:nota.est.numdigits ;
     skos:prefLabel "nota.est.numdigits.prod" .
 
@@ -887,6 +1013,7 @@ eliozo:nota.est.numdigits.sum a eliozo:Skill ;
     eliozo:skillDescription "Novērtēt ciparu skaitu divu vai vairāku skaitļu summā" ;
     eliozo:skillID "nota.est.numdigits.sum" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.1.1.1.0" ;
     skos:broader eliozo:nota.est.numdigits ;
     skos:prefLabel "nota.est.numdigits.sum" .
 
@@ -894,6 +1021,7 @@ eliozo:seq.arithm.expr a eliozo:Skill ;
     eliozo:skillDescription "Izmantot aritmētiskas progresijas vispārīgā locekļa formulu $a_n=a_1+(n-1) \\cdot d$" ;
     eliozo:skillID "seq.arithm.expr" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "5.1.1.0.0" ;
     skos:broader eliozo:seq.arithm ;
     skos:prefLabel "seq.arithm.expr" .
 
@@ -901,6 +1029,7 @@ eliozo:seq.arithm.mod.all a eliozo:Skill ;
     eliozo:skillDescription "Secināt, ka aritm. progresija pieņem visus atlikumus, dalot ar p, ja $\\mbox{LKD}(d,p)=1$" ;
     eliozo:skillID "seq.arithm.mod.all" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "5.1.5.2.0" ;
     skos:broader eliozo:seq.arithm.mod ;
     skos:prefLabel "seq.arithm.mod.all" .
 
@@ -908,6 +1037,7 @@ eliozo:seq.arithm.mod.gaps a eliozo:Skill ;
     eliozo:skillDescription "Secināt, ka katrs p-tais aritm. progresijas loceklis dalās ar p, ja $\\mbox{LKD}(d,p)=1$" ;
     eliozo:skillID "seq.arithm.mod.gaps" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "5.1.5.1.0" ;
     skos:broader eliozo:seq.arithm.mod ;
     skos:prefLabel "seq.arithm.mod.gaps" .
 
@@ -915,6 +1045,7 @@ eliozo:seq.arithm.numestimate a eliozo:Skill ;
     eliozo:skillDescription "Novērtēt skaitļu skaitu, kas dalās ar d starp pirmajiem n skaitļiem ar [n/d] (un vispārināt citām aritmētiskām progresijām)" ;
     eliozo:skillID "seq.arithm.numestimate" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "5.1.2.0.0" ;
     skos:broader eliozo:seq.arithm ;
     skos:prefLabel "seq.arithm.numestimate" .
 
@@ -922,6 +1053,7 @@ eliozo:seq.arithm.pairsum a eliozo:Skill ;
     eliozo:skillDescription "Izmantot spriedumos aritmētiskas progresijas locekļu \"pretējo pāru\" summu vienādību" ;
     eliozo:skillID "seq.arithm.pairsum" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "5.1.3.0.0" ;
     skos:broader eliozo:seq.arithm ;
     skos:prefLabel "seq.arithm.pairsum" .
 
@@ -929,6 +1061,7 @@ eliozo:seq.arithm.summation a eliozo:Skill ;
     eliozo:skillDescription "Izmantot aritmētiskas progresijas summas formulu" ;
     eliozo:skillID "seq.arithm.summation" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "5.1.4.0.0" ;
     skos:broader eliozo:seq.arithm ;
     skos:prefLabel "seq.arithm.summation" .
 
@@ -936,6 +1069,7 @@ eliozo:seq.gaps.cubes a eliozo:Skill ;
     eliozo:skillDescription "Izmantot to, ka pilnu kubu atstarpes aug kā kvadrātiska funkcija" ;
     eliozo:skillID "seq.gaps.cubes" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "5.4.2.0.0" ;
     skos:broader eliozo:seq.gaps ;
     skos:prefLabel "seq.gaps.cubes" .
 
@@ -943,6 +1077,7 @@ eliozo:seq.gaps.geom a eliozo:Skill ;
     eliozo:skillDescription "Izmantot to, ka $2^n$ locekļu starpības aug ģeometriskā progresijā." ;
     eliozo:skillID "seq.gaps.geom" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "5.4.3.0.0" ;
     skos:broader eliozo:seq.gaps ;
     skos:prefLabel "seq.gaps.geom" .
 
@@ -950,6 +1085,7 @@ eliozo:seq.gaps.squares a eliozo:Skill ;
     eliozo:skillDescription "Izmantot to, ka pilnu kvadrātu atstarpes aug aritmētiskā progresijā." ;
     eliozo:skillID "seq.gaps.squares" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "5.4.1.0.0" ;
     skos:broader eliozo:seq.gaps ;
     skos:prefLabel "seq.gaps.squares" .
 
@@ -957,6 +1093,7 @@ eliozo:seq.geom.decnotation a eliozo:Skill ;
     eliozo:skillDescription "Izteikt skaitļus, kuru pierakstā atkārtojas ciparu grupas, ar ģeometrisku progresiju" ;
     eliozo:skillID "seq.geom.decnotation" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "5.2.1.0.0" ;
     skos:broader eliozo:seq.geom ;
     skos:prefLabel "seq.geom.decnotation" .
 
@@ -964,6 +1101,7 @@ eliozo:seq.geom.estimate a eliozo:Skill ;
     eliozo:skillDescription "Novērtēt, cik reizes skaitli vajag reizināt vai dalīt ar kaut ko, lai iegūtu vajadzīgo vērtību." ;
     eliozo:skillID "seq.geom.estimate" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "5.2.3.0.0" ;
     skos:broader eliozo:seq.geom ;
     skos:prefLabel "seq.geom.estimate" .
 
@@ -971,6 +1109,7 @@ eliozo:seq.geom.infinite a eliozo:Skill ;
     eliozo:skillDescription "Izmantot bezgalīgas ģeometriskas progresijas, piemēram, nosakot bezgalīgas decimāldaļas" ;
     eliozo:skillID "seq.geom.infinite" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "5.2.4.0.0" ;
     skos:broader eliozo:seq.geom ;
     skos:prefLabel "seq.geom.infinite" .
 
@@ -978,6 +1117,7 @@ eliozo:seq.geom.summation a eliozo:Skill ;
     eliozo:skillDescription "Izmantot galīgas ģeometriskas progresijas summas formulu" ;
     eliozo:skillID "seq.geom.summation" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "5.2.2.0.0" ;
     skos:broader eliozo:seq.geom ;
     skos:prefLabel "seq.geom.summation" .
 
@@ -985,6 +1125,7 @@ eliozo:seq.recur.fibonacci a eliozo:Skill ;
     eliozo:skillDescription "Izmantot Fibonači skaitļu jēdzienu vienkāršu secinājumu izdarīšanai" ;
     eliozo:skillID "seq.recur.fibonacci" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "5.3.1.0.0" ;
     skos:broader eliozo:seq.recur ;
     skos:prefLabel "seq.recur.fibonacci" .
 
@@ -992,6 +1133,7 @@ eliozo:seq.recur.linear a eliozo:Skill ;
     eliozo:skillDescription "Izmantot rekurentu virkņu īpašības, kas aprakstāmas ar lineāru izteiksmi" ;
     eliozo:skillID "seq.recur.linear" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "5.3.2.0.0" ;
     skos:broader eliozo:seq.recur ;
     skos:prefLabel "seq.recur.linear" .
 
@@ -999,6 +1141,7 @@ eliozo:seq.recur.other a eliozo:Skill ;
     eliozo:skillDescription "Izmantot citu rekurenti definētu virkņu īpašības" ;
     eliozo:skillID "seq.recur.other" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "5.3.3.0.0" ;
     skos:broader eliozo:seq.recur ;
     skos:prefLabel "seq.recur.other" .
 
@@ -1006,6 +1149,7 @@ eliozo:alg.poly.prop a eliozo:Skill ;
     eliozo:skillDescription "Lietot rezultātus par 1 mainīgā polinomiem ar veseliem koeficientiem" ;
     eliozo:skillID "alg.poly.prop" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.7.3.0.0" ;
     skos:broader eliozo:alg.poly ;
     skos:narrower eliozo:alg.poly.prop.valdiff ;
     skos:prefLabel "alg.poly.prop" .
@@ -1014,6 +1158,7 @@ eliozo:alg.sets.sqrt a eliozo:Skill ;
     eliozo:skillDescription "Secināt par kvadrātsakņu izteiksmju racionalitāti vai iracionalitāti" ;
     eliozo:skillID "alg.sets.sqrt" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.8.2.0.0" ;
     skos:broader eliozo:alg.sets ;
     skos:narrower eliozo:alg.sets.sqrt.pythagoras ;
     skos:prefLabel "alg.sets.sqrt" .
@@ -1022,6 +1167,7 @@ eliozo:comb.grid a eliozo:Skill ;
     eliozo:skillDescription "Izmantot rūtiņu laukuma īpašības" ;
     eliozo:skillID "comb.grid" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "6.5.0.0.0" ;
     skos:broader eliozo:comb ;
     skos:narrower eliozo:comb.grid.shapes ;
     skos:prefLabel "comb.grid" .
@@ -1030,6 +1176,7 @@ eliozo:comb.grid.shapes a eliozo:Skill ;
     eliozo:skillDescription "Veidot figūriņas pa rūtiņu līnijām" ;
     eliozo:skillID "comb.grid.shapes" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "6.5.1.0.0" ;
     skos:broader eliozo:comb.grid ;
     skos:narrower eliozo:comb.grid.shapes.cutting ;
     skos:prefLabel "comb.grid.shapes" .
@@ -1038,6 +1185,7 @@ eliozo:geom.circle a eliozo:Skill ;
     eliozo:skillDescription "Izmantot riņķa līnijas ģeometriskās īpašības" ;
     eliozo:skillID "geom.circle" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "8.2.0.0.0" ;
     skos:broader eliozo:geom ;
     skos:narrower eliozo:geom.circle.inscribed ;
     skos:prefLabel "geom.circle" .
@@ -1046,6 +1194,7 @@ eliozo:geom.quadrangle.trapezoid a eliozo:Skill ;
     eliozo:skillDescription "Izmantot trapeču ģeometriskās īpašības" ;
     eliozo:skillID "geom.quadrangle.trapezoid" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "8.4.3.0.0" ;
     skos:broader eliozo:geom.quadrangle ;
     skos:narrower eliozo:geom.quadrangle.trapezoid.area ;
     skos:prefLabel "geom.quadrangle.trapezoid" .
@@ -1054,6 +1203,7 @@ eliozo:geom.triangle.area a eliozo:Skill ;
     eliozo:skillDescription "Izmantot trijstūru laukuma formulas" ;
     eliozo:skillID "geom.triangle.area" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "8.3.1.0.0" ;
     skos:broader eliozo:geom.triangle ;
     skos:narrower eliozo:geom.triangle.area.ah2 ;
     skos:prefLabel "geom.triangle.area" .
@@ -1062,6 +1212,7 @@ eliozo:nota.combine.poly a eliozo:Skill ;
     eliozo:skillDescription "Izteikt skaitli ar decimālpieraksta cipariem, reizinot ar $10^k$" ;
     eliozo:skillID "nota.combine.poly" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.3.1.0.0" ;
     skos:broader eliozo:nota.combine ;
     skos:narrower eliozo:nota.combine.poly.pieces ;
     skos:prefLabel "nota.combine.poly" .
@@ -1070,6 +1221,7 @@ eliozo:nota.est a eliozo:Skill ;
     eliozo:skillDescription "Izmantot skaitļa decimālpierakstu" ;
     eliozo:skillID "nota.est" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.1.0.0.0" ;
     skos:broader eliozo:nota ;
     skos:narrower eliozo:nota.est.numdigits ;
     skos:prefLabel "nota.est" .
@@ -1078,6 +1230,7 @@ eliozo:alg.equ.quadratic a eliozo:Skill ;
     eliozo:skillDescription "Analizēt un risināt kvadrātvienādojumus" ;
     eliozo:skillID "alg.equ.quadratic" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.3.2.0.0" ;
     skos:broader eliozo:alg.equ ;
     skos:narrower eliozo:alg.equ.quadratic.discriminant,
         eliozo:alg.equ.quadratic.roots ;
@@ -1087,6 +1240,7 @@ eliozo:alg.expr a eliozo:Skill ;
     eliozo:skillDescription "Ieviest mainīgo apzīmējumus, sastādīt ar tiem izteiksmes" ;
     eliozo:skillID "alg.expr" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.1.0.0.0" ;
     skos:broader eliozo:alg ;
     skos:narrower eliozo:alg.expr.prop,
         eliozo:alg.expr.selectvar ;
@@ -1096,6 +1250,7 @@ eliozo:alg.linear a eliozo:Skill ;
     eliozo:skillDescription "Izmantot linearitāti veicot pārveidojumus vai kombinējot rezultātus" ;
     eliozo:skillID "alg.linear" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.6.0.0.0" ;
     skos:broader eliozo:alg ;
     skos:narrower eliozo:alg.linear.comb,
         eliozo:alg.linear.equations ;
@@ -1105,6 +1260,7 @@ eliozo:alg.sets a eliozo:Skill ;
     eliozo:skillDescription "Izmantot dažādu skaitļu kopu īpašības" ;
     eliozo:skillID "alg.sets" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.8.0.0.0" ;
     skos:broader eliozo:alg ;
     skos:narrower eliozo:alg.sets.irrat,
         eliozo:alg.sets.sqrt ;
@@ -1114,6 +1270,7 @@ eliozo:alg.tra.factor a eliozo:Skill ;
     eliozo:skillDescription "Dalīt reizinātājos algebriskas izteiksmes" ;
     eliozo:skillID "alg.tra.factor" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.2.2.0.0" ;
     skos:broader eliozo:alg.tra ;
     skos:narrower eliozo:alg.tra.factor.powdiff,
         eliozo:alg.tra.factor.sqdiff ;
@@ -1123,6 +1280,7 @@ eliozo:alg.tra.pow a eliozo:Skill ;
     eliozo:skillDescription "Izmantot pakāpju īpašības" ;
     eliozo:skillID "alg.tra.pow" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.2.3.0.0" ;
     skos:broader eliozo:alg.tra ;
     skos:narrower eliozo:alg.tra.pow.nest,
         eliozo:alg.tra.pow.prod ;
@@ -1132,6 +1290,7 @@ eliozo:comb.count.mult a eliozo:Skill ;
     eliozo:skillDescription "Izmantot \"reizināšanas likumu\" novērtējot kombināciju skaitu" ;
     eliozo:skillID "comb.count.mult" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "6.2.1.0.0" ;
     skos:broader eliozo:comb.count ;
     skos:narrower eliozo:comb.count.mult.norep,
         eliozo:comb.count.mult.rep ;
@@ -1141,6 +1300,7 @@ eliozo:comb.full a eliozo:Skill ;
     eliozo:skillDescription "Veikt pilno pārlasi" ;
     eliozo:skillID "comb.full" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "6.1.0.0.0" ;
     skos:broader eliozo:comb ;
     skos:narrower eliozo:comb.full.backtrack,
         eliozo:comb.full.syntax ;
@@ -1150,6 +1310,7 @@ eliozo:div.common a eliozo:Skill ;
     eliozo:skillDescription "Izmantot LKD un MKD jēdzienus (common multipliers, divisors)" ;
     eliozo:skillID "div.common" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.3.0.0.0" ;
     skos:broader eliozo:div ;
     skos:narrower eliozo:div.common.gcd,
         eliozo:div.common.lcm ;
@@ -1159,6 +1320,7 @@ eliozo:div.prop.primes a eliozo:Skill ;
     eliozo:skillDescription "Izmantot pirmskaitļu īpašības" ;
     eliozo:skillID "div.prop.primes" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.1.3.0.0" ;
     skos:broader eliozo:div.prop ;
     skos:narrower eliozo:div.prop.primes.inf,
         eliozo:div.prop.primes.small ;
@@ -1168,6 +1330,7 @@ eliozo:div.valu a eliozo:Skill ;
     eliozo:skillDescription "Izmantot spriedumus par valuāciju (lielāko pirmskaitļa pakāpi, ar ko dalās n)" ;
     eliozo:skillID "div.valu" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.5.0.0.0" ;
     skos:broader eliozo:div ;
     skos:narrower eliozo:div.valu.change,
         eliozo:div.valu.prop ;
@@ -1177,6 +1340,7 @@ eliozo:geom.constr a eliozo:Skill ;
     eliozo:skillDescription "Veikt ģeometriskas konstrukcijas uzdevumu risināšanā." ;
     eliozo:skillID "geom.constr" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "8.1.0.0.0" ;
     skos:broader eliozo:geom ;
     skos:narrower eliozo:geom.constr.small,
         eliozo:geom.constr.triangulate ;
@@ -1190,6 +1354,7 @@ eliozo:geom.triangle a eliozo:Skill ;
     eliozo:skillDescription "Izmantot trijstūru ģeometriskās īpašības" ;
     eliozo:skillID "geom.triangle" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "8.3.0.0.0" ;
     skos:broader eliozo:geom ;
     skos:narrower eliozo:geom.triangle.area,
         eliozo:geom.triangle.congruence ;
@@ -1199,6 +1364,7 @@ eliozo:misc.extr a eliozo:Skill ;
     eliozo:skillDescription "Izmantot spriedumus par ekstrēmo elementu" ;
     eliozo:skillID "misc.extr" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "7.2.0.0.0" ;
     skos:broader eliozo:misc ;
     skos:narrower eliozo:misc.extr.param,
         eliozo:misc.extr.pigeon ;
@@ -1208,6 +1374,7 @@ eliozo:misc.ind a eliozo:Skill ;
     eliozo:skillDescription "Pamatot ar matemātisko indukciju" ;
     eliozo:skillID "misc.ind" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "7.4.0.0.0" ;
     skos:broader eliozo:misc ;
     skos:narrower eliozo:misc.ind.descent,
         eliozo:misc.ind.least ;
@@ -1217,6 +1384,7 @@ eliozo:misc.symm a eliozo:Skill ;
     eliozo:skillDescription "Izmantot uzdevumā esošo simetriju" ;
     eliozo:skillID "misc.symm" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "7.5.0.0.0" ;
     skos:broader eliozo:misc ;
     skos:narrower eliozo:misc.symm.periodicity,
         eliozo:misc.symm.rename ;
@@ -1226,6 +1394,7 @@ eliozo:nota.divrule.2_5_10 a eliozo:Skill ;
     eliozo:skillDescription "Izmantot dalāmības pazīmes ar 2 vai 5, vai 10" ;
     eliozo:skillID "nota.divrule.2_5_10" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.2.1.0.0" ;
     skos:broader eliozo:nota.divrule ;
     skos:narrower eliozo:nota.divrule.2_5_10.divides,
         eliozo:nota.divrule.2_5_10.rem ;
@@ -1235,6 +1404,7 @@ eliozo:nota.divrule.2_5pow a eliozo:Skill ;
     eliozo:skillDescription "Izmantot dalāmības pazīmes ar $2^a \\cdot 5^b$" ;
     eliozo:skillID "nota.divrule.2_5pow" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.2.2.0.0" ;
     skos:broader eliozo:nota.divrule ;
     skos:narrower eliozo:nota.divrule.2_5pow.divides,
         eliozo:nota.divrule.2_5pow.rem ;
@@ -1244,6 +1414,7 @@ eliozo:nota.divrule.3_9 a eliozo:Skill ;
     eliozo:skillDescription "Izmantot dalāmības pazīmes ar 3 vai 9" ;
     eliozo:skillID "nota.divrule.3_9" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.2.3.0.0" ;
     skos:broader eliozo:nota.divrule ;
     skos:narrower eliozo:nota.divrule.3_9.divides,
         eliozo:nota.divrule.3_9.rem ;
@@ -1253,6 +1424,7 @@ eliozo:nota.est.numdigits a eliozo:Skill ;
     eliozo:skillDescription "Novērtēt ciparu skaitu dažādu darbību rezultātos" ;
     eliozo:skillID "nota.est.numdigits" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.1.1.0.0" ;
     skos:broader eliozo:nota.est ;
     skos:narrower eliozo:nota.est.numdigits.prod,
         eliozo:nota.est.numdigits.sum ;
@@ -1262,6 +1434,7 @@ eliozo:seq.arithm.mod a eliozo:Skill ;
     eliozo:skillDescription "Secināt par aritmētiskas progresijas locekļu atlikumiem" ;
     eliozo:skillID "seq.arithm.mod" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "5.1.5.0.0" ;
     skos:broader eliozo:seq.arithm ;
     skos:narrower eliozo:seq.arithm.mod.all,
         eliozo:seq.arithm.mod.gaps ;
@@ -1271,6 +1444,7 @@ eliozo:alg.equ a eliozo:Skill ;
     eliozo:skillDescription "Risināt algebriskus vienādojumus ar piemērotām standartmetodēm" ;
     eliozo:skillID "alg.equ" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.3.0.0.0" ;
     skos:broader eliozo:alg ;
     skos:narrower eliozo:alg.equ.guess,
         eliozo:alg.equ.parametrize,
@@ -1281,6 +1455,7 @@ eliozo:alg.poly a eliozo:Skill ;
     eliozo:skillDescription "Lietot polinomu īpašības" ;
     eliozo:skillID "alg.poly" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.7.0.0.0" ;
     skos:broader eliozo:alg ;
     skos:narrower eliozo:alg.poly.division,
         eliozo:alg.poly.homo,
@@ -1291,6 +1466,7 @@ eliozo:alg.series a eliozo:Skill ;
     eliozo:skillDescription "Pārveidot un secināt par garām summām un reizinājumiem" ;
     eliozo:skillID "alg.series" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.4.0.0.0" ;
     skos:broader eliozo:alg ;
     skos:narrower eliozo:alg.series.mean,
         eliozo:alg.series.prod,
@@ -1301,6 +1477,7 @@ eliozo:alg.tra.binom a eliozo:Skill ;
     eliozo:skillDescription "Pārveidot reizinājumus un pakāpes, kuros ietilpst binomi" ;
     eliozo:skillID "alg.tra.binom" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.2.1.0.0" ;
     skos:broader eliozo:alg.tra ;
     skos:narrower eliozo:alg.tra.binom.complsquare,
         eliozo:alg.tra.binom.newton,
@@ -1311,6 +1488,7 @@ eliozo:comb.count a eliozo:Skill ;
     eliozo:skillDescription "Saskaitīt variantus, izmantojot kombinatorisko analīzi" ;
     eliozo:skillID "comb.count" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "6.2.0.0.0" ;
     skos:broader eliozo:comb ;
     skos:narrower eliozo:comb.count.complement,
         eliozo:comb.count.inclexcl,
@@ -1321,6 +1499,7 @@ eliozo:comb.graph a eliozo:Skill ;
     eliozo:skillDescription "Izmantot grafu rezultātus" ;
     eliozo:skillID "comb.graph" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "6.3.0.0.0" ;
     skos:broader eliozo:comb ;
     skos:narrower eliozo:comb.graph.bfs,
         eliozo:comb.graph.bipartite,
@@ -1331,6 +1510,7 @@ eliozo:div a eliozo:Skill ;
     eliozo:skillDescription "Izmantot veselu skaitļu dalāmību" ;
     eliozo:skillID "div" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.0.0.0.0" ;
     skos:narrower eliozo:div.common,
         eliozo:div.fta,
         eliozo:div.prop,
@@ -1341,6 +1521,7 @@ eliozo:div.common.gcd a eliozo:Skill ;
     eliozo:skillDescription "Izmantot LKD jēdzienu" ;
     eliozo:skillID "div.common.gcd" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.3.2.0.0" ;
     skos:broader eliozo:div.common ;
     skos:narrower eliozo:div.common.gcd.bezout,
         eliozo:div.common.gcd.euclid,
@@ -1351,6 +1532,7 @@ eliozo:div.common.lcm a eliozo:Skill ;
     eliozo:skillDescription "Atrast mazāko kopīgo dalāmo (MKD)" ;
     eliozo:skillID "div.common.lcm" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.3.1.0.0" ;
     skos:broader eliozo:div.common ;
     skos:narrower eliozo:div.common.lcm.frac,
         eliozo:div.common.lcm.maxexp,
@@ -1361,6 +1543,7 @@ eliozo:div.fta.pow a eliozo:Skill ;
     eliozo:skillDescription "Pazīt pilnus kvadrātus u.c. pilnas pakāpes pēc skaitļa sadalījuma pirmreizinātājos" ;
     eliozo:skillID "div.fta.pow" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.2.3.0.0" ;
     skos:broader eliozo:div.fta ;
     skos:narrower eliozo:div.fta.pow.expsystem,
         eliozo:div.fta.pow.other,
@@ -1371,6 +1554,7 @@ eliozo:geom a eliozo:Skill ;
     eliozo:skillDescription "Izmantot ģeometrijas rezultātus un metodes." ;
     eliozo:skillID "geom" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "8.0.0.0.0" ;
     skos:narrower eliozo:geom.circle,
         eliozo:geom.constr,
         eliozo:geom.quandrangle,
@@ -1381,6 +1565,7 @@ eliozo:misc.extr.pigeon a eliozo:Skill ;
     eliozo:skillDescription "Izmantot Dirihlē principu" ;
     eliozo:skillID "misc.extr.pigeon" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "7.2.1.0.0" ;
     skos:broader eliozo:misc.extr ;
     skos:narrower eliozo:misc.extr.pigeon.collection,
         eliozo:misc.extr.pigeon.floor,
@@ -1391,6 +1576,7 @@ eliozo:mod.eq a eliozo:Skill ;
     eliozo:skillDescription "Secināt par kongruenču vienādojumiem un risināt tos (t.sk. ar lineāriem pārveidojumiem - pieskaitot, atņemot vai reizinot ar skaitli)" ;
     eliozo:skillID "mod.eq" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "3.6.0.0.0" ;
     skos:broader eliozo:mod ;
     skos:narrower eliozo:mod.eq.chinese,
         eliozo:mod.eq.contradict,
@@ -1401,6 +1587,7 @@ eliozo:mod.exp a eliozo:Skill ;
     eliozo:skillDescription "Izmantot eksponentfunkciju atlikumu īpašības." ;
     eliozo:skillID "mod.exp" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "3.4.0.0.0" ;
     skos:broader eliozo:mod ;
     skos:narrower eliozo:mod.exp.fermat,
         eliozo:mod.exp.inverse,
@@ -1411,6 +1598,7 @@ eliozo:mod.fix a eliozo:Skill ;
     eliozo:skillDescription "Izmantot atlikumu sistēmas galīgumu pēc neliela, fiksēta moduļa" ;
     eliozo:skillID "mod.fix" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "3.1.0.0.0" ;
     skos:broader eliozo:mod ;
     skos:narrower eliozo:mod.fix.clock,
         eliozo:mod.fix.lastdigits,
@@ -1421,6 +1609,7 @@ eliozo:nota a eliozo:Skill ;
     eliozo:skillDescription "Izmantot spriedumos skaitļa pierakstu" ;
     eliozo:skillID "nota" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.0.0.0.0" ;
     skos:narrower eliozo:nota.algor,
         eliozo:nota.combine,
         eliozo:nota.divrule,
@@ -1431,6 +1620,7 @@ eliozo:nota.combine a eliozo:Skill ;
     eliozo:skillDescription "Saprast, kā mainās skaitlis, ja tajā pārvieto vai iesprauž ciparus" ;
     eliozo:skillID "nota.combine" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.3.0.0.0" ;
     skos:broader eliozo:nota ;
     skos:narrower eliozo:nota.combine.padding,
         eliozo:nota.combine.poly,
@@ -1441,6 +1631,7 @@ eliozo:seq a eliozo:Skill ;
     eliozo:skillDescription "Lietot zināšanas par veselu skaitļu virknēm" ;
     eliozo:skillID "seq" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "5.0.0.0.0" ;
     skos:narrower eliozo:seq.arithm,
         eliozo:seq.gaps,
         eliozo:seq.geom,
@@ -1451,6 +1642,7 @@ eliozo:seq.gaps a eliozo:Skill ;
     eliozo:skillDescription "Izmantot spriedumus par dažu virkņu kaimiņu locekļu starpībām" ;
     eliozo:skillID "seq.gaps" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "5.4.0.0.0" ;
     skos:broader eliozo:seq ;
     skos:narrower eliozo:seq.gaps.cubes,
         eliozo:seq.gaps.geom,
@@ -1461,6 +1653,7 @@ eliozo:seq.recur a eliozo:Skill ;
     eliozo:skillDescription "Veikt spriedumus par pazīstamām virknēm, kas nav progresijas" ;
     eliozo:skillID "seq.recur" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "5.3.0.0.0" ;
     skos:broader eliozo:seq ;
     skos:narrower eliozo:seq.recur.fibonacci,
         eliozo:seq.recur.linear,
@@ -1471,6 +1664,7 @@ eliozo:alg.tra a eliozo:Skill ;
     eliozo:skillDescription "Veikt algebriskus pārveidojumus" ;
     eliozo:skillID "alg.tra" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.2.0.0.0" ;
     skos:broader eliozo:alg ;
     skos:narrower eliozo:alg.tra.binom,
         eliozo:alg.tra.factor,
@@ -1482,6 +1676,7 @@ eliozo:comb a eliozo:Skill ;
     eliozo:skillDescription "Izmantot kombinatoriskus spriedumus" ;
     eliozo:skillID "comb" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "6.0.0.0.0" ;
     skos:narrower eliozo:comb.constr,
         eliozo:comb.count,
         eliozo:comb.full,
@@ -1493,6 +1688,7 @@ eliozo:comb.constr a eliozo:Skill ;
     eliozo:skillDescription "Konstruēt piemērus atbilstoši dotajām īpašībām" ;
     eliozo:skillID "comb.constr" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "6.4.0.0.0" ;
     skos:broader eliozo:comb ;
     skos:narrower eliozo:comb.constr.alpha,
         eliozo:comb.constr.color,
@@ -1504,6 +1700,7 @@ eliozo:div.fta a eliozo:Skill ;
     eliozo:skillDescription "Izmantot vesela skaitļa izteiksmi pirmskaitļu reizinājumā (Fundamental theorem of arithmetic)" ;
     eliozo:skillID "div.fta" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.2.0.0.0" ;
     skos:broader eliozo:div ;
     skos:narrower eliozo:div.fta.divisors,
         eliozo:div.fta.factorial,
@@ -1515,6 +1712,7 @@ eliozo:misc a eliozo:Skill ;
     eliozo:skillDescription "Izmantot dažādas ārpus skaitļu teorijas pazīstamas metodes" ;
     eliozo:skillID "misc" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "7.0.0.0.0" ;
     skos:narrower eliozo:misc.extr,
         eliozo:misc.ind,
         eliozo:misc.invar,
@@ -1526,6 +1724,7 @@ eliozo:misc.invar a eliozo:Skill ;
     eliozo:skillDescription "Izmantot invariantus" ;
     eliozo:skillID "misc.invar" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "7.3.0.0.0" ;
     skos:broader eliozo:misc ;
     skos:narrower eliozo:misc.invar.congr,
         eliozo:misc.invar.expr,
@@ -1537,6 +1736,7 @@ eliozo:mod a eliozo:Skill ;
     eliozo:skillDescription "Izmantot spriedumus par skaitļu atlikumiem, dalot ar to pašu" ;
     eliozo:skillID "mod" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "3.0.0.0.0" ;
     skos:narrower eliozo:mod.congr,
         eliozo:mod.eq,
         eliozo:mod.exp,
@@ -1548,6 +1748,7 @@ eliozo:nota.algor a eliozo:Skill ;
     eliozo:skillDescription "Izmantot ar pozicionālo pierakstu saistītos algoritmus" ;
     eliozo:skillID "nota.algor" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.4.0.0.0" ;
     skos:broader eliozo:nota ;
     skos:narrower eliozo:nota.algor.arithm,
         eliozo:nota.algor.fast,
@@ -1559,6 +1760,7 @@ eliozo:seq.geom a eliozo:Skill ;
     eliozo:skillDescription "Izmantot ģeometriskas progresijas īpašības" ;
     eliozo:skillID "seq.geom" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "5.2.0.0.0" ;
     skos:broader eliozo:seq ;
     skos:narrower eliozo:seq.geom.decnotation,
         eliozo:seq.geom.estimate,
@@ -1570,6 +1772,7 @@ eliozo:alg.ineq a eliozo:Skill ;
     eliozo:skillDescription "Pamatot un izmantot nevienādības" ;
     eliozo:skillID "alg.ineq" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.5.0.0.0" ;
     skos:broader eliozo:alg ;
     skos:narrower eliozo:alg.ineq.equations,
         eliozo:alg.ineq.monotonicity,
@@ -1582,6 +1785,7 @@ eliozo:div.fta.divisors a eliozo:Skill ;
     eliozo:skillDescription "Izdarīt spriedumus par skaitļa dalītājiem, ja tas izteikts kā reizinājums." ;
     eliozo:skillID "div.fta.divisors" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.2.2.0.0" ;
     skos:broader eliozo:div.fta ;
     skos:narrower eliozo:div.fta.divisors.frac,
         eliozo:div.fta.divisors.num,
@@ -1594,6 +1798,7 @@ eliozo:div.prop a eliozo:Skill ;
     eliozo:skillDescription "Secināt, izmantojot vienkāršas dalāmības īpašības" ;
     eliozo:skillID "div.prop" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.1.0.0.0" ;
     skos:broader eliozo:div ;
     skos:narrower eliozo:div.prop.add,
         eliozo:div.prop.composite,
@@ -1606,6 +1811,7 @@ eliozo:div.valu.prop a eliozo:Skill ;
     eliozo:skillDescription "Izmantot valuāciju īpašības" ;
     eliozo:skillID "div.valu.prop" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "2.5.1.0.0" ;
     skos:broader eliozo:div.valu ;
     skos:narrower eliozo:div.valu.prop.legendre,
         eliozo:div.valu.prop.min,
@@ -1618,6 +1824,7 @@ eliozo:mod.congr a eliozo:Skill ;
     eliozo:skillDescription "Izmantot apgalvojumus par skaitļa izteikšanu ar dalījumu un atlikumu (a=bq+r) un kongruenču klases." ;
     eliozo:skillID "mod.congr" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "3.2.0.0.0" ;
     skos:broader eliozo:mod ;
     skos:narrower eliozo:mod.congr.classes,
         eliozo:mod.congr.poly,
@@ -1630,6 +1837,7 @@ eliozo:seq.arithm a eliozo:Skill ;
     eliozo:skillDescription "Lietot zināšanas par aritmētiskām progresijām" ;
     eliozo:skillID "seq.arithm" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "5.1.0.0.0" ;
     skos:broader eliozo:seq ;
     skos:narrower eliozo:seq.arithm.expr,
         eliozo:seq.arithm.mod,
@@ -1642,6 +1850,7 @@ eliozo:alg a eliozo:Skill ;
     eliozo:skillDescription "Izmantot algebriskos apzīmējumus un metodes skaitļu teorijas uzdevumos" ;
     eliozo:skillID "alg" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "1.0.0.0.0" ;
     skos:narrower eliozo:alg.equ,
         eliozo:alg.expr,
         eliozo:alg.ineq,
@@ -1656,6 +1865,7 @@ eliozo:nota.divrule a eliozo:Skill ;
     eliozo:skillDescription "Izmantot dalāmības pazīmes" ;
     eliozo:skillID "nota.divrule" ;
     eliozo:skillName "TBD" ;
+    eliozo:skillNumber "4.2.0.0.0" ;
     skos:broader eliozo:nota ;
     skos:narrower eliozo:nota.divrule.1001,
         eliozo:nota.divrule.101,


### PR DESCRIPTION
SPARQL izlaboti, lai izmantotu tās īpašības, kas ir ontoloģijā (un kopš vakardienas arī Fuseki). 
Atlikta atpakaļ arī `eliozo:skillNumber` īpašība - jo to vajadzēja, lai prasmju lapu varētu uzzīmēt.